### PR TITLE
228 | Add check if pending_email_lower exists, return 403 if falsy

### DIFF
--- a/api/.eslintrc
+++ b/api/.eslintrc
@@ -2,7 +2,7 @@
     "parserOptions": {
         ecmaVersion: 8,
         sourceType: 'module'
-    }
+    },
     "extends": "eslint:recommended",
     "ecmaFeatures" : {
         "modules"        : true,

--- a/api/server.js
+++ b/api/server.js
@@ -23,8 +23,11 @@ manifestPromise.then(manifest => {
         try {
           let token = await bookshelf.model('email_token')
             .forge({ token: id })
-            .where('expires_at', '>', bookshelf.knex.fn.now())
             .fetch();
+          if (token && token.get('expires_at') < new Date()) {
+            // Token is expired
+            return false;
+          }
           if (!token) {
             token = await bookshelf.model('user_password_reset_token')
               .forge({ token })

--- a/api/server.js
+++ b/api/server.js
@@ -21,19 +21,11 @@ manifestPromise.then(manifest => {
     server.auth.strategy('oidc_session', 'oidc_session');
     server.auth.strategy('email_token', 'email_token', {
       findToken: async id => {
-        try {
-          let token = await bookshelf.model('email_token')
-            .forge({ token: id })
-            .fetch();
-          if (token && moment().isAfter(token.get('expires_at'))) {
-            // Token is expired
-            return false;
-          }
-          return token;
-        }
-        catch (error){
-          throw error;
-        }
+        let token = await bookshelf.model('email_token')
+          .forge({ token: id })
+          .where('expires_at', '>', bookshelf.knex.fn.now())
+          .fetch();
+        return token;
       },
       findUser: async(id) => {
         return await bookshelf.model('user').where({ id }).fetch();

--- a/api/server.js
+++ b/api/server.js
@@ -21,20 +21,20 @@ manifestPromise.then(manifest => {
     server.auth.strategy('email_token', 'email_token', {
       findToken: async id => {
         try {
-        let token = await bookshelf.model('email_token')
-          .forge({ token: id })
-          .where('expires_at', '>', bookshelf.knex.fn.now())
-          .fetch();
-        if (!token) {
-          token = await bookshelf.model('user_password_reset_token')
-            .forge({ token })
+          let token = await bookshelf.model('email_token')
+            .forge({ token: id })
             .where('expires_at', '>', bookshelf.knex.fn.now())
             .fetch();
-        }
-        return token;
+          if (!token) {
+            token = await bookshelf.model('user_password_reset_token')
+              .forge({ token })
+              .where('expires_at', '>', bookshelf.knex.fn.now())
+              .fetch();
+          }
+          return token;
         }
         catch (error){
-          return error;
+          throw error;
         }
       },
       findUser: async(id) => {

--- a/api/server.js
+++ b/api/server.js
@@ -20,11 +20,11 @@ manifestPromise.then(manifest => {
     server.auth.strategy('oidc_session', 'oidc_session');
     server.auth.strategy('email_token', 'email_token', {
       findToken: async id => {
+        try {
         let token = await bookshelf.model('email_token')
           .forge({ token: id })
           .where('expires_at', '>', bookshelf.knex.fn.now())
           .fetch();
-
         if (!token) {
           token = await bookshelf.model('user_password_reset_token')
             .forge({ token })
@@ -32,6 +32,10 @@ manifestPromise.then(manifest => {
             .fetch();
         }
         return token;
+        }
+        catch (error){
+          return error;
+        }
       },
       findUser: async(id) => {
         return await bookshelf.model('user').where({ id }).fetch();

--- a/api/server.js
+++ b/api/server.js
@@ -4,7 +4,6 @@ const handlebars = require('handlebars');
 const manifestPromise = require('./manifest');
 const bookshelf = require('./src/lib/bookshelf');
 const logger = require('./src/lib/logger');
-const moment = require('moment');
 
 var options = {
   relativeTo: __dirname + '/src'

--- a/api/server.js
+++ b/api/server.js
@@ -4,6 +4,7 @@ const handlebars = require('handlebars');
 const manifestPromise = require('./manifest');
 const bookshelf = require('./src/lib/bookshelf');
 const logger = require('./src/lib/logger');
+const moment = require('moment');
 
 var options = {
   relativeTo: __dirname + '/src'
@@ -24,15 +25,9 @@ manifestPromise.then(manifest => {
           let token = await bookshelf.model('email_token')
             .forge({ token: id })
             .fetch();
-          if (token && token.get('expires_at') < new Date()) {
+          if (token && moment().isAfter(token.get('expires_at'))) {
             // Token is expired
             return false;
-          }
-          if (!token) {
-            token = await bookshelf.model('user_password_reset_token')
-              .forge({ token })
-              .where('expires_at', '>', bookshelf.knex.fn.now())
-              .fetch();
           }
           return token;
         }

--- a/api/src/application/user/user-controller.js
+++ b/api/src/application/user/user-controller.js
@@ -53,12 +53,11 @@ module.exports = (
           await userEmails.sendChangeEmailVerifyEmail(user, client, email, request.query);
           break;
         case 'cancel_new':
-          const emailToken = bookshelf.model('email_token').where({user_id:user.get('id')})
+          await bookshelf.model('email_token').where({user_id:user.get('id')}).destroy()
           user.set('pending_email', null);
           user.set('pending_email_lower', null);
 
           await user.save();
-          await emailToken.destroy();
           break;
         case 'change':
           const isAuthenticated = await comparePasswords(current, user);

--- a/api/src/application/user/user-controller.js
+++ b/api/src/application/user/user-controller.js
@@ -148,6 +148,10 @@ module.exports = (
       const user = request.auth.credentials.user;
       const client = await clientService.findById(request.query.client_id);
 
+      if (!user.get('pending_email_lower')) {
+        console.error('pending_email_lower returned falsy value');
+        return reply(Boom.forbidden());
+      }
       if (!error) {
         const userCollection = await bookshelf.model('user').where({email_lower: user.get('pending_email_lower')}).fetchAll();
 
@@ -172,9 +176,9 @@ module.exports = (
 
       const template = await themeService.renderThemedTemplate(request.query.client_id, 'email-verify-success', viewContext);
       if (template) {
-        reply(template);
+        return reply(template);
       } else {
-        reply.view('email-verify-success', viewContext);
+        return reply.view('email-verify-success', viewContext);
       }
     },
 

--- a/api/src/application/user/user-controller.js
+++ b/api/src/application/user/user-controller.js
@@ -53,9 +53,12 @@ module.exports = (
           await userEmails.sendChangeEmailVerifyEmail(user, client, email, request.query);
           break;
         case 'cancel_new':
+          const emailToken = bookshelf.model('email_token').where({user_id:user.get('id')})
           user.set('pending_email', null);
           user.set('pending_email_lower', null);
+
           await user.save();
+          await emailToken.destroy();
           break;
         case 'change':
           const isAuthenticated = await comparePasswords(current, user);

--- a/api/src/application/user/user-controller.js
+++ b/api/src/application/user/user-controller.js
@@ -148,10 +148,6 @@ module.exports = (
       const user = request.auth.credentials.user;
       const client = await clientService.findById(request.query.client_id);
 
-      if (!user.get('pending_email_lower')) {
-        console.error('pending_email_lower returned falsy value');
-        return reply(Boom.forbidden());
-      }
       if (!error) {
         const userCollection = await bookshelf.model('user').where({email_lower: user.get('pending_email_lower')}).fetchAll();
 

--- a/api/src/application/user/user-routes.js
+++ b/api/src/application/user/user-routes.js
@@ -16,7 +16,7 @@ const queryValidation = {
   login: Joi.string().optional(),
 };
 
-module.exports = (service, controller, mixedValidation, ValidationError, server, formHandler, rowExists, tokenValidator, clientValidator) => {
+module.exports = (service, controller, mixedValidation, ValidationError, server, formHandler, rowExists, emailChangeTokenValidator, clientValidator) => {
   const emailValidator = async (value, options) => {
     const userCollection = await bookshelf.model('user').where({email_lower: value.toLowerCase()}).fetchAll();
     if (userCollection.length >= 1) {
@@ -121,7 +121,7 @@ module.exports = (service, controller, mixedValidation, ValidationError, server,
             client_id: Joi.string().required(),
             redirect_uri: Joi.string().required(),
           }, {
-            token: tokenValidator,
+            token: emailChangeTokenValidator,
             client_id: clientValidator,
           }),
         },
@@ -411,6 +411,6 @@ module.exports['@require'] = [
   'server',
   'form-handler',
   'validator/constraints/row-exists',
-  'validator/constraints/token-validator',
+  'validator/constraints/email-change-token-validator',
   'validator/constraints/client-validator',
 ];

--- a/api/src/application/user/user-routes.js
+++ b/api/src/application/user/user-routes.js
@@ -16,7 +16,7 @@ const queryValidation = {
   login: Joi.string().optional(),
 };
 
-module.exports = (service, controller, mixedValidation, ValidationError, server, formHandler, rowExists, clientValidator) => {
+module.exports = (service, controller, mixedValidation, ValidationError, server, formHandler, rowExists, tokenValidator, clientValidator) => {
   const emailValidator = async (value, options) => {
     const userCollection = await bookshelf.model('user').where({email_lower: value.toLowerCase()}).fetchAll();
     if (userCollection.length >= 1) {
@@ -121,6 +121,7 @@ module.exports = (service, controller, mixedValidation, ValidationError, server,
             client_id: Joi.string().required(),
             redirect_uri: Joi.string().required(),
           }, {
+            token: tokenValidator,
             client_id: clientValidator,
           }),
         },
@@ -410,5 +411,6 @@ module.exports['@require'] = [
   'server',
   'form-handler',
   'validator/constraints/row-exists',
+  'validator/constraints/token-validator',
   'validator/constraints/client-validator',
 ];

--- a/api/src/lib/validator/constraints/email-change-token-validator.js
+++ b/api/src/lib/validator/constraints/email-change-token-validator.js
@@ -1,18 +1,17 @@
-const Boom = require('boom');
 const bookshelf = require('../../bookshelf');
 
 module.exports = (ValidationError) => async (value, options) => {
   const tokenQuery = bookshelf.model('email_token').where({token: value});
   const token = await tokenQuery.fetch();
-  const userQuery = bookshelf.model('user').where({id: token.get('user_id')})
+  const userQuery = bookshelf.model('user').where({id: token.get('user_id')});
   const user = await userQuery.fetch();
   const badEmailToken = new ValidationError('That email token is no longer good');
   if (!user.get('pending_email_lower') || !user.get('pending_email')) {
     // Email change has been canceled
     throw badEmailToken;
   }
-  return value
-}
+  return value;
+};
 
 module.exports['@singleton'] = true;
 module.exports['@require'] = ['validator/validation-error'];

--- a/api/src/lib/validator/constraints/token-validator.js
+++ b/api/src/lib/validator/constraints/token-validator.js
@@ -6,9 +6,9 @@ module.exports = (server, ValidationError) => async (value, options) => {
   const token = await tokenQuery.fetch();
   const userQuery = bookshelf.model('user').where({id: token.get('user_id')})
   const user = await userQuery.fetch();
-  if (!user.get('pending_email_lower')) {
+  const badEmailToken = new ValidationError('That email token is no longer good');
+  if (!user.get('pending_email_lower') || !user.get('pending_email')) {
     // Email change has been canceled
-    const badEmailToken = new ValidationError('That email token is no longer good');
     throw badEmailToken;
   }
   return value

--- a/api/src/lib/validator/constraints/token-validator.js
+++ b/api/src/lib/validator/constraints/token-validator.js
@@ -1,7 +1,7 @@
 const Boom = require('boom');
 const bookshelf = require('../../bookshelf');
 
-module.exports = (server, ValidationError) => async (value, options) => {
+module.exports = (ValidationError) => async (value, options) => {
   const tokenQuery = bookshelf.model('email_token').where({token: value});
   const token = await tokenQuery.fetch();
   const userQuery = bookshelf.model('user').where({id: token.get('user_id')})
@@ -15,4 +15,4 @@ module.exports = (server, ValidationError) => async (value, options) => {
 }
 
 module.exports['@singleton'] = true;
-module.exports['@require'] = ['server', 'validator/validation-error'];
+module.exports['@require'] = ['validator/validation-error'];

--- a/api/src/lib/validator/constraints/token-validator.js
+++ b/api/src/lib/validator/constraints/token-validator.js
@@ -1,0 +1,18 @@
+const Boom = require('boom');
+const bookshelf = require('../../bookshelf');
+
+module.exports = (server, ValidationError) => async (value, options) => {
+  const tokenQuery = bookshelf.model('email_token').where({token: value});
+  const token = await tokenQuery.fetch();
+  const userQuery = bookshelf.model('user').where({id: token.get('user_id')})
+  const user = await userQuery.fetch();
+  if (!user.get('pending_email_lower')) {
+    // Email change has been canceled
+    const badEmailToken = new ValidationError('That email token is no longer good');
+    throw badEmailToken;
+  }
+  return value
+}
+
+module.exports['@singleton'] = true;
+module.exports['@require'] = ['server', 'validator/validation-error'];

--- a/api/src/plugins/email-token-scheme.js
+++ b/api/src/plugins/email-token-scheme.js
@@ -7,9 +7,6 @@ exports.register = function (server, pluginOptions, next) {
       async authenticate(request, reply) {
         try {
           var token = await schemeOptions.findToken(request.query.token);
-          if (token.name === 'TypeError') {
-            return reply(Boom.forbidden())
-          }
           var user = token ? await schemeOptions.findUser(token.get('user_id')) : null;
         } catch(e) {
           return reply(e);

--- a/api/src/plugins/email-token-scheme.js
+++ b/api/src/plugins/email-token-scheme.js
@@ -8,11 +8,11 @@ exports.register = function (server, pluginOptions, next) {
         try {
           var token = await schemeOptions.findToken(request.query.token);
           if (token.name === 'TypeError') {
-            reply(Boom.forbidden())
+            return reply(Boom.forbidden())
           }
           var user = token ? await schemeOptions.findUser(token.get('user_id')) : null;
         } catch(e) {
-          reply(e);
+          return reply(e);
         }
 
         if (token && user) {
@@ -23,7 +23,7 @@ exports.register = function (server, pluginOptions, next) {
             }
           });
         } else {
-          reply(Boom.forbidden());
+          return reply(Boom.forbidden());
         }
       }
 

--- a/api/src/plugins/email-token-scheme.js
+++ b/api/src/plugins/email-token-scheme.js
@@ -7,6 +7,9 @@ exports.register = function (server, pluginOptions, next) {
       async authenticate(request, reply) {
         try {
           var token = await schemeOptions.findToken(request.query.token);
+          if (token.name === 'TypeError') {
+            reply(Boom.forbidden())
+          }
           var user = token ? await schemeOptions.findUser(token.get('user_id')) : null;
         } catch(e) {
           reply(e);


### PR DESCRIPTION
Adds a try/catch in server.js findToken function.
Then, uses the error caught from that in email-token-scheme in order to throw a 403 instead of a 500 in the case that a good token isn't found. 

Also adds a tokenValidator to check if the token has been canceled, which sets the pending_email and pending_email_lower to null. 

Related to: 
Using cancelled email verification link returns a 500 error #228