### PR TITLE
268 add default keystore warning

### DIFF
--- a/api/src/lib/fetch-keystore.js
+++ b/api/src/lib/fetch-keystore.js
@@ -1,13 +1,14 @@
 const AWS = require('aws-sdk');
-const s3 = new AWS.S3({apiVersion: '2006-03-01'});
+const s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 const defaultKeystore = require('../../keystore');
+const logger = require('./logger');
 
 module.exports = function() {
   return new Promise((resolve, reject) => {
     if (process.env.KEYSTORE && process.env.KEYSTORE_BUCKET) {
       var params = {
-        Bucket: process.env.KEYSTORE_BUCKET, /* required */
-        Key: process.env.KEYSTORE, /* required */
+        Bucket: process.env.KEYSTORE_BUCKET /* required */,
+        Key: process.env.KEYSTORE /* required */,
       };
       s3.getObject(params, function(err, data) {
         if (err) {
@@ -19,6 +20,9 @@ module.exports = function() {
         }
       });
     } else {
+      const msg =
+        'DEPRECATION WARNING:\nThe Synapse OpenID Connect platform provides a default set of keys so that\nit will work if you do not provide your own, but \n\nDO NOT USE THE DEFAULTS IN PRODUCTION.\n\nUse of these keys in a non-development environment will be removed\nin the next version and OIDC will not start.';
+      logger.log('info', msg);
       resolve(defaultKeystore);
     }
   });

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,7 @@ Each release of the Synapse OIDC Platform is built as a docker public docker ima
 | REDIS_PORT                | Set if different from default '6379' |
 
 ## Keystores
+DEPRECATION WARNING: The Synapse OpenID Connect platform provides a default set of keys so that it will work if you do not provide your own, but DO NOT USE THE DEFAULTS IN PRODUCTION. Use of these keys in a non-development environment will be removed in the next version and OIDC will not start.
 
 node-oidc-provider uses [node-jose](https://github.com/cisco/node-jose) keys and stores to encrypt, sign and decrypt things (mostly tokens and stuff). For security purposes YOU SHOULD PROVIDE YOUR OWN KEYS. The synapse OpenID Connect platform provides a default set of keys so that it will work if you do not provide your own, but PLEASE DO NOT USE THE DEFAULTS IN PRODUCTION.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,9 +18,9 @@ Each release of the Synapse OIDC Platform is built as a docker public docker ima
 | REDIS_PORT                | Set if different from default '6379' |
 
 ## Keystores
-DEPRECATION WARNING: The Synapse OpenID Connect platform provides a default set of keys so that it will work if you do not provide your own, but DO NOT USE THE DEFAULTS IN PRODUCTION. Use of these keys in a non-development environment will be removed in the next version and OIDC will not start.
+**DEPRECATION WARNING:** The Synapse OpenID Connect platform provides a default set of keys so that it will work if you do not provide your own, but **DO NOT USE THE DEFAULTS IN PRODUCTION**. Use of these keys in a non-development environment will be removed in the next version and OIDC will not start.
 
-node-oidc-provider uses [node-jose](https://github.com/cisco/node-jose) keys and stores to encrypt, sign and decrypt things (mostly tokens and stuff). For security purposes YOU SHOULD PROVIDE YOUR OWN KEYS. The synapse OpenID Connect platform provides a default set of keys so that it will work if you do not provide your own, but PLEASE DO NOT USE THE DEFAULTS IN PRODUCTION.
+node-oidc-provider uses [node-jose](https://github.com/cisco/node-jose) keys and stores to encrypt, sign and decrypt things (mostly tokens and stuff). For security purposes **YOU SHOULD PROVIDE YOUR OWN KEYS**. The synapse OpenID Connect platform provides a default set of keys so that it will work if you do not provide your own, but **PLEASE DO NOT USE THE DEFAULTS IN PRODUCTION.**
 
 ### Generating Keys
 


### PR DESCRIPTION
Adds a deprecation warning using the logger, updates documentation with deprecation warning. 
![screen shot 2018-03-14 at 2 02 57 pm](https://user-images.githubusercontent.com/13124650/37430768-74dab2a2-2790-11e8-8c7e-c4d894a90845.png)


Related to: 
Console warning if using default keystore #268 