### PR TITLE
269 convert all logs to winston

### DIFF
--- a/api/src/application/email/drivers/mailgun.js
+++ b/api/src/application/email/drivers/mailgun.js
@@ -2,6 +2,7 @@
 
 const Mailgun = require('mailgun-js');
 const checkWhitelist = require('../check-whitelist');
+const logger = require('../../../lib/logger');
 
 module.exports = function () {
 
@@ -58,7 +59,7 @@ module.exports = function () {
 
         mailgunClient.messages().send(mail, (error, body) => {
           if (error) {
-            console.log(error, mail);
+            logger.info(error, mail);
             reject(error);
           }
           else {

--- a/api/src/application/email/drivers/mailgun.js
+++ b/api/src/application/email/drivers/mailgun.js
@@ -59,7 +59,7 @@ module.exports = function () {
 
         mailgunClient.messages().send(mail, (error, body) => {
           if (error) {
-            logger.info(error, mail);
+            logger.error(error, mail);
             reject(error);
           }
           else {

--- a/api/src/application/email/email-service.js
+++ b/api/src/application/email/email-service.js
@@ -1,6 +1,7 @@
 const config = require('../../../config');
 const mailgun = require('./drivers/mailgun');
 const ses = require('./drivers/ses');
+const logger = require('../../lib/logger');
 
 const drivers = { mailgun, ses };
 
@@ -10,7 +11,7 @@ module.exports = () => {
   } else {
     return {
       send: () => {
-        console.log(`You're attempting to send an email without an email provider configured!`);
+        logger.error(`You're attempting to send an email without an email provider configured!`);
       }
     };
   }

--- a/api/src/application/image/image-service.js
+++ b/api/src/application/image/image-service.js
@@ -1,5 +1,6 @@
 const s3 = require('aws-sdk').S3;
 const s3Bucket = require('../../../config')('/aws/s3Bucket');
+const logger = require('../../lib/logger');
 
 module.exports = () => ({
   uploadImageStream(stream, key) {
@@ -23,7 +24,8 @@ module.exports = () => ({
         });
     })
       .catch((error) => {
-        console.trace(error);
+        const trace = new Error(error);
+        logger.error(trace);
         throw error;
       });
   },
@@ -42,7 +44,8 @@ module.exports = () => ({
         });
     })
       .catch((error) => {
-        console.trace(error);
+        const trace = new Error(error);
+        logger.error(trace);
         throw error;
       });
   },

--- a/api/src/application/user/user-controller.js
+++ b/api/src/application/user/user-controller.js
@@ -11,6 +11,7 @@ const userFormData = require('./user-form-data');
 const comparePasswords = require('../../lib/comparePasswords');
 const bookshelf = require('../../lib/bookshelf');
 const webhookService = require('../webhook/webhook-service');
+const logger = require('../../lib/logger');
 
 // e.g. convert { foo.bar: 'baz' } to { foo: { bar: 'baz' }}
 const expandDotPaths = function(object) {
@@ -225,7 +226,7 @@ module.exports = (
       const sessionId = request.state._session;
 
       if (!sessionId) {
-        console.error('Session id cookie not present');
+        logger.error('Session id cookie not present');
         reply(Boom.notFound());
       } else {
         userService.invalidateSession(sessionId)

--- a/api/src/bin/drop-tables.js
+++ b/api/src/bin/drop-tables.js
@@ -1,16 +1,17 @@
 #! /usr/bin/env node
+const logger = require('../lib/logger');
 var ioc = require('./cli-app');
 
 var knex = require('../lib/knex');
 
 if (process.env.NODE_ENV === 'production') {
-  console.log('In production. Not going to drop tables.');
+  logger.warn('In production. Not going to drop tables.');
 } else {
   knex.schema
     .raw('DROP SCHEMA public CASCADE')
     .raw('CREATE SCHEMA public')
     .then(() => {
-      console.log('Dropped tables');
+      logger.info('Dropped tables');
       process.exit(0);
     });
 }

--- a/api/src/bin/generate-keys.js
+++ b/api/src/bin/generate-keys.js
@@ -2,8 +2,9 @@ const fs = require('fs');
 const { createKeyStore } = require('oidc-provider');
 const certificateKeystore = createKeyStore();
 const integrityKeystore = createKeyStore();
+const logger = require('../lib/logger');
 
-console.log('Generating keys. This will take a few seconds...');
+logger.info('Generating keys. This will take a few seconds...');
 Promise.all([
   certificateKeystore.generate('RSA', 2048, {
     kid: 'sig-rs-0',
@@ -41,6 +42,6 @@ Promise.all([
   fs.open('./keystore.json', 'w', (err, fd) => {
     const keystores = certificateKeystore.toJSON(true);
     fs.write(fd, JSON.stringify(keystores));
-    console.log('Done! Created keystore.json\n');
+    logger.info('Done! Created keystore.json\n');
   });
 });

--- a/api/src/lib/fetch-keystore.js
+++ b/api/src/lib/fetch-keystore.js
@@ -1,6 +1,7 @@
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3({apiVersion: '2006-03-01'});
 const defaultKeystore = require('../../keystore');
+const logger = require('./logger');
 
 module.exports = function() {
   return new Promise((resolve, reject) => {
@@ -11,8 +12,9 @@ module.exports = function() {
       };
       s3.getObject(params, function(err, data) {
         if (err) {
-          console.error('Error fetching keystores from s3');
-          console.trace(err);
+          logger.error('Error fetching keystores from s3');
+          const trace = new Error(err);
+          logger.error(trace);
           reject(err);
         } else {
           resolve(JSON.parse(data.Body.toString()));

--- a/api/src/lib/format-error.js
+++ b/api/src/lib/format-error.js
@@ -1,8 +1,9 @@
 var Boom = require('boom');
+const logger = require('./logger');
 
 module.exports = function(error) {
   if (!error.data || !error.data.details) {
-    console.error(error);
+    logger.error(error);
     return error.isBoom ? error : Boom.badImplementation(error);
   }
 

--- a/api/src/plugins/openid-connect/openid-connect.js
+++ b/api/src/plugins/openid-connect/openid-connect.js
@@ -38,14 +38,14 @@ exports.register = function (server, options, next) {
       });
 
       server.views(options.vision);
-      addRoutes(server, issuer, options)
+      addRoutes(server, issuer, options);
 
       server.expose('provider', provider);
 
       next();
     })
     .catch(e => {
-      console.error(e);
+      logger.error(e);
     });
 };
 


### PR DESCRIPTION
Replaces console.fn* with Winston. 

For traces I created a new error object, allowing the message to point to where that log is coming from, instead of the package it is coming from. 

Related to:
Locate any instance of logging that does t use Winston and make it use Winston #269