### PR TITLE
274 invalid client id in user registration gives 500

### DIFF
--- a/api/src/application/user/user-routes.js
+++ b/api/src/application/user/user-routes.js
@@ -7,16 +7,18 @@ const clientInitiatedLogout = require('../../../config')('/clientInitiatedLogout
 const userRegistration = require('../../../config')('/userRegistration');
 const bookshelf = require('../../lib/bookshelf');
 
-const queryValidation = {
-  client_id : Joi.string().required(),
-  response_type : Joi.string().required(),
-  scope : Joi.string().required(),
-  redirect_uri : Joi.string().required(),
-  nonce : Joi.string().optional(),
-  login: Joi.string().optional(),
-};
 
 module.exports = (service, controller, mixedValidation, ValidationError, server, formHandler, rowExists, emailChangeTokenValidator, clientValidator) => {
+  const queryValidation = mixedValidation({
+    client_id: Joi.string().required(),
+    response_type: Joi.string().required(),
+    scope: Joi.string().required(),
+    redirect_uri: Joi.string().required(),
+    nonce: Joi.string().optional(),
+    login: Joi.string().optional(),
+  },{
+    client_id: clientValidator,
+  });
   const emailValidator = async (value, options) => {
     const userCollection = await bookshelf.model('user').where({email_lower: value.toLowerCase()}).fetchAll();
     if (userCollection.length >= 1) {

--- a/api/src/lib/form-handler.js
+++ b/api/src/lib/form-handler.js
@@ -6,6 +6,9 @@ module.exports = (
   clientService
 ) => {
   return (templateName, getView, postHandler) => async (request, reply, source, error) => {
+    if (error && error.output.statusCode === 404) {
+      reply(error);
+    }
     try {
       const client = await clientService.findById(request.query.client_id);
       let user = null;

--- a/api/src/lib/form-handler.js
+++ b/api/src/lib/form-handler.js
@@ -7,7 +7,7 @@ module.exports = (
 ) => {
   return (templateName, getView, postHandler) => async (request, reply, source, error) => {
     if (error && error.output.statusCode === 404) {
-      reply(error);
+      return reply(error);
     }
     try {
       const client = await clientService.findById(request.query.client_id);
@@ -22,9 +22,9 @@ module.exports = (
         const viewContext = getView(user, client, request, e);
         const template = await themeService.renderThemedTemplate(request.query.client_id, templateName, viewContext);
         if (template) {
-          reply(template);
+          return reply(template);
         } else {
-          reply.view(templateName, viewContext);
+          return reply.view(templateName, viewContext);
         }
       }
 
@@ -34,7 +34,7 @@ module.exports = (
         await render(error);
       }
     } catch(e) {
-      reply(e);
+      return reply(e);
     }
   };
 };


### PR DESCRIPTION
Add mixedValidation to queryValidation in order to validate client_id.

Add conditional to reply with a 404 if client isn't found, because the form's error handling is for validation specifically. 

Related to: 
Using an invalid client_id in user registration url leads to a 500 #274