### PR TITLE
Add cookie validation to /interaction/ routes

### DIFF
--- a/api/src/plugins/openid-connect/addRoutes.js
+++ b/api/src/plugins/openid-connect/addRoutes.js
@@ -1,3 +1,4 @@
+const Joi = require('joi');
 const querystring = require('querystring');
 const views = require('./views');
 
@@ -29,6 +30,14 @@ module.exports = (server, issuer, options) => {
       }
     },
     config: {
+      validate: {
+        headers: {
+          cookie: Joi.string().required(),
+        },
+        options: {
+          allowUnknown: true,
+        }
+      },
       state: {
         parse: false // hapi fails to parse oidc cookie...
       }
@@ -43,6 +52,14 @@ module.exports = (server, issuer, options) => {
       server.plugins['open-id-connect'].provider.interactionFinished(request.raw.req, request.raw.res, result);
     },
     config: {
+      validate: {
+        headers: {
+          cookie: Joi.string().required(),
+        },
+        options: {
+          allowUnknown: true,
+        }
+      },
       state: {
         parse: false
       }
@@ -81,9 +98,17 @@ module.exports = (server, issuer, options) => {
       }
     },
     config: {
+      validate: {
+        headers: {
+          cookie: Joi.string().required(),
+        },
+        options: {
+          allowUnknown: true,
+        }
+      },
       state: {
         parse: false
       }
     }
   });
-}
+};


### PR DESCRIPTION
Previously there would be an error when provider checks the request and sets a cookie variable, returning a 500. 

Adds validation to prevent it from getting to that point and return a 400 if they don't have a cookie. 

Related to:
Users with browsers set to not allow cookies get 500 error #273