### PR TITLE
Support Custom Email Subject

### DIFF
--- a/api/src/application/api/api-routes.js
+++ b/api/src/application/api/api-routes.js
@@ -26,6 +26,7 @@ module.exports = (userService, clientService, mixedValidation, rowNotExists, row
             nonce: Joi.string(),
             app_metadata: Joi.object(),
             profile: Joi.object(),
+            subject: Joi.string(),
             template: Joi.string(),
             hours_till_expiration: hoursTillExpirationSchema,
           },

--- a/api/src/application/user/user-emails.js
+++ b/api/src/application/user/user-emails.js
@@ -130,10 +130,13 @@ module.exports = (emailService, themeService, renderTemplate, emailTokenService)
       const clientHoursTilExpiration = hoursTilExpiration ? hoursTilExpiration : client.get('hours_til_expiration')
       const token = await emailTokenService.create(user.get('id'), hoursTilExpiration, saveOptions);
       const viewContext = userViews.inviteEmail(user, client, config('/baseUrl'), {...query, token: token.get('token')});
+      console.log('viewContext', viewContext)
 
       if(query.subject) {
         viewContext.subject = query.subject;
       }
+
+      console.log('viewContext after', viewContext);
 
       if (templateOverride) {
         const emailTemplate = handlebars.compile(templateOverride);

--- a/api/src/application/user/user-emails.js
+++ b/api/src/application/user/user-emails.js
@@ -136,7 +136,7 @@ module.exports = (emailService, themeService, renderTemplate, emailTokenService)
         const emailBody = emailTemplate(viewContext);
         await emailService.send({
           to: user.get('email'),
-          subject: templateOverride.subject || viewContext.subject,
+          subject: query.subject || viewContext.subject,
           html: emailBody,
         });
       } else {

--- a/api/src/application/user/user-emails.js
+++ b/api/src/application/user/user-emails.js
@@ -131,10 +131,6 @@ module.exports = (emailService, themeService, renderTemplate, emailTokenService)
       const token = await emailTokenService.create(user.get('id'), hoursTilExpiration, saveOptions);
       const viewContext = userViews.inviteEmail(user, client, config('/baseUrl'), {...query, token: token.get('token')});
 
-      if(query.subject) {
-        viewContext.subject = query.subject;
-      }
-
       if (templateOverride) {
         const emailTemplate = handlebars.compile(templateOverride);
         const emailBody = emailTemplate(viewContext);

--- a/api/src/application/user/user-emails.js
+++ b/api/src/application/user/user-emails.js
@@ -131,12 +131,16 @@ module.exports = (emailService, themeService, renderTemplate, emailTokenService)
       const token = await emailTokenService.create(user.get('id'), hoursTilExpiration, saveOptions);
       const viewContext = userViews.inviteEmail(user, client, config('/baseUrl'), {...query, token: token.get('token')});
 
+      if(query.subject) {
+        viewContext.subject = query.subject;
+      }
+
       if (templateOverride) {
         const emailTemplate = handlebars.compile(templateOverride);
         const emailBody = emailTemplate(viewContext);
         await emailService.send({
           to: user.get('email'),
-          subject: query.subject || viewContext.subject,
+          subject: viewContext.subject,
           html: emailBody,
         });
       } else {

--- a/api/src/application/user/user-emails.js
+++ b/api/src/application/user/user-emails.js
@@ -136,7 +136,7 @@ module.exports = (emailService, themeService, renderTemplate, emailTokenService)
         const emailBody = emailTemplate(viewContext);
         await emailService.send({
           to: user.get('email'),
-          subject: viewContext.subject,
+          subject: templateOverride.subject || viewContext.subject,
           html: emailBody,
         });
       } else {

--- a/api/src/application/user/user-emails.js
+++ b/api/src/application/user/user-emails.js
@@ -130,13 +130,10 @@ module.exports = (emailService, themeService, renderTemplate, emailTokenService)
       const clientHoursTilExpiration = hoursTilExpiration ? hoursTilExpiration : client.get('hours_til_expiration')
       const token = await emailTokenService.create(user.get('id'), hoursTilExpiration, saveOptions);
       const viewContext = userViews.inviteEmail(user, client, config('/baseUrl'), {...query, token: token.get('token')});
-      console.log('viewContext', viewContext)
 
       if(query.subject) {
         viewContext.subject = query.subject;
       }
-
-      console.log('viewContext after', viewContext);
 
       if (templateOverride) {
         const emailTemplate = handlebars.compile(templateOverride);

--- a/api/src/application/user/user-views.js
+++ b/api/src/application/user/user-views.js
@@ -323,6 +323,6 @@ module.exports = {
     client: client.serialize({strictOidc:true}),
     url: `${baseUrl}/user/accept-invite?${querystring.stringify(query)}`.replace(' ', '%20'),
     appName: client.get('client_name'),
-    subject: `${client.get('client_name')} Invitation`,
+    subject: query.subject ? query.subject : `${client.get('client_name')} Invitation`,
   }),
 };


### PR DESCRIPTION
#317 
The Reason I broke this out into an endpoint string is because if we need to assign a custom email tag for "You have an invite from Bob Jenkins" or something of that nature, that can all be supplied programatically.

Using a template tag would have been another option, and actually still can be an option, but this allows a customized string.