### PR TITLE
376 user/profile endpoint finished that authenticates via access_token

### DIFF
--- a/api/manifest.js
+++ b/api/manifest.js
@@ -18,7 +18,7 @@ if (env === 'development') {
   connections[0].tls = {
     key: fs.readFileSync('dev.key'),
     cert: fs.readFileSync('dev.crt'),
-  }
+  };
 
   connections.push({ port: 9001 });
 }
@@ -43,6 +43,9 @@ module.exports = Promise.all([
     server: {
       connections: {
         routes: {
+          cors: {
+            origin: ['*'],
+          },
           validate: {
             options: { abortEarly: false },
             failAction: (request, reply, source, error) => {

--- a/api/src/application/api/api-routes.js
+++ b/api/src/application/api/api-routes.js
@@ -299,34 +299,6 @@ module.exports = (userService, clientService, mixedValidation, rowNotExists, row
       }
     }
   },
-  // {
-  //   method: 'PUT',
-  //   path: '/api/user/{user}/profile',
-  //   handler: async (request, reply) => {
-  //     reply(apiService.updateUserProfile(request.params.user, request.payload));
-  //   },
-  //   config: {
-  //     payload: filePayloadConfig,
-  //     auth: {
-  //       strategy: 'client_credentials',
-  //       scope: 'admin',
-  //     },
-  //     validate: {
-  //       params: mixedValidation({
-  //         user: Joi.any().required(),
-  //       }, {
-  //         user: rowExists('user', 'id', 'User not found')
-  //       }),
-  //       payload: userProfilePayloadValidation,
-  //       query: mixedValidation({
-  //         client_id: Joi.string().required(),
-  //         redirect_uri: Joi.string().required(),
-  //       }, {
-  //         client_id: clientValidator,
-  //       }),
-  //     }
-  //   }
-  // },
 ];
 
 module.exports['@singleton'] = true;

--- a/api/src/application/api/api-service.js
+++ b/api/src/application/api/api-service.js
@@ -1,0 +1,61 @@
+const webhookService = require('../webhook/webhook-service');
+const Uuid = require('uuid');
+const set = require('lodash/set');
+
+// e.g. convert { foo.bar: 'baz' } to { foo: { bar: 'baz' }}
+const expandDotPaths = function(object) {
+  Object.keys(object).forEach(key => {
+    if (key.indexOf('.') > -1) {
+      const value = object[key];
+      delete(object[key]);
+      set(object, key, value);
+    }
+  });
+  return object;
+};
+
+module.exports = (userService, imageService) => {
+  return {
+    async updateUserProfile(user, requestPayload) {
+      let profile = user.get('profile');
+      const { shouldClearPicture, ...originalPayload } = requestPayload;
+      const payload = expandDotPaths(originalPayload);
+
+      const oldPicture = profile.picture;
+      const pictureMIME = originalPayload.picture
+        ? originalPayload.picture.hapi.headers['content-type']
+        : null;
+
+      if (pictureMIME === 'image/jpeg' || pictureMIME === 'image/png') {
+        const uuid = Uuid();
+        const bucket = uuid.substring(0, 2);
+        const filename = await imageService.uploadImageStream(originalPayload.picture, `pictures/${bucket}/${uuid}`);
+
+        profile = Object.assign(profile, payload, { picture: filename });
+      } else {
+        delete originalPayload.picture;
+        if (shouldClearPicture) {
+          profile = Object.assign(profile, payload, {picture: null});
+        } else {
+          profile = Object.assign(profile, payload);
+        }
+      }
+
+      user = await userService.update(user.get('id'), { profile });
+      webhookService.trigger('user.update', user);
+
+      if (oldPicture) {
+        await imageService.deleteImage(oldPicture.replace(/^.*\/\/[^\/]+\//, ''));
+      }
+
+      return user;
+    },
+
+  };
+};
+
+module.exports['@singleton'] = true;
+module.exports['@require'] = [
+  'user/user-service',
+  'image/image-service',
+];

--- a/test-client/package.json
+++ b/test-client/package.json
@@ -20,5 +20,5 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "https://sso-client.test:9000"
 }

--- a/test-client/package.json
+++ b/test-client/package.json
@@ -19,6 +19,5 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
-  },
-  "proxy": "https://sso-client.test:9000"
+  }
 }

--- a/test-client/src/App.js
+++ b/test-client/src/App.js
@@ -6,6 +6,7 @@ import config from './config';
 import './App.css';
 
 import InviteUserForm from './components/InviteUserForm';
+import UserProfileForm from './components/UserProfileForm';
 
 const history = createHistory();
 
@@ -97,6 +98,7 @@ class App extends Component {
         </div>
         <div>
           <InviteUserForm />
+          <UserProfileForm />
           <div><a href={`https://sso-client.test:9000/user/profile?client_id=${config.clientId}&redirect_uri=${config.redirectUri}&access_token=${this.state.accessToken}`}>Edit Profile</a></div>
           <div><a href={`https://sso-client.test:9000/user/password?client_id=${config.clientId}&redirect_uri=${config.redirectUri}`}>Change Password</a></div>
           <div><a href={`https://sso-client.test:9000/user/email-settings?client_id=${config.clientId}&redirect_uri=${config.redirectUri}`}>Email Settings</a></div>

--- a/test-client/src/components/InviteUserForm.js
+++ b/test-client/src/components/InviteUserForm.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
+import config from '../config';
 
 class InviteUserForm extends Component {
   constructor(props){
     super(props);
 
-    this.state = { 
+    this.state = {
       name: '',
       email: '',
       showMessage: false,
@@ -15,7 +16,7 @@ class InviteUserForm extends Component {
 
   updateForm(fieldName, e) {
     const field = {};
-    field[fieldName] = (e.target.type === 'checkbox') 
+    field[fieldName] = (e.target.type === 'checkbox')
       ? e.target.checked : e.target.value;
     this.setState(field);
   }
@@ -27,7 +28,7 @@ class InviteUserForm extends Component {
       email: this.state.email,
       useTemplate: this.state.useTemplate,
     };
-    fetch('/invite', {
+    fetch(`${config.testServer}invite`, {
       method: 'POST',
       body: JSON.stringify(data),
     }).then((data) => {
@@ -36,7 +37,7 @@ class InviteUserForm extends Component {
       const message = `Message sent to ${data.email}`;
       this.setState({ showMessage: true, message });
       setTimeout(() => {
-        this.setState({ 
+        this.setState({
           name: '',
           email: '',
           showMessage: false,
@@ -51,8 +52,8 @@ class InviteUserForm extends Component {
     return (
       <div>
         <form
-          onSubmit={this.submitForm.bind(this)} 
-          style={{ 
+          onSubmit={this.submitForm.bind(this)}
+          style={{
             border: 'thin solid black',
             padding: '10px',
             width: '400px',
@@ -63,11 +64,11 @@ class InviteUserForm extends Component {
             padding: '10px',
           }}>
             <label htmlFor="name" style={{ width: '100px', textAlign: 'left' }}>Name:</label>
-            <input 
-              type="text" 
-              name="name" 
-              id="name" 
-              value={this.state.name} 
+            <input
+              type="text"
+              name="name"
+              id="name"
+              value={this.state.name}
               placeholder="Enter a name"
               onChange={(e) => this.updateForm.call(this, 'name', e)}
               required
@@ -79,12 +80,12 @@ class InviteUserForm extends Component {
             padding: '10px',
           }}>
             <label htmlFor="email" style={{ width: '100px', textAlign: 'left' }}>Email:</label>
-            <input 
-              type="email" 
-              name="email" 
-              id="email" 
-              value={this.state.email} 
-              placeholder="Enter an email" 
+            <input
+              type="email"
+              name="email"
+              id="email"
+              value={this.state.email}
+              placeholder="Enter an email"
               onChange={(e) => this.updateForm.call(this, 'email', e)}
               required
               style={{
@@ -95,10 +96,10 @@ class InviteUserForm extends Component {
             padding: '10px',
           }}>
             <label htmlFor="use-template" style={{ width: '100px', textAlign: 'left' }}>Use Email Template:</label>
-            <input 
-              type="checkbox" 
-              name="use-template" 
-              id="use-template" 
+            <input
+              type="checkbox"
+              name="use-template"
+              id="use-template"
               checked={this.state.useTemplate}
               onChange={(e) => this.updateForm.call(this, 'useTemplate', e)}
               style={{
@@ -108,9 +109,9 @@ class InviteUserForm extends Component {
           <div style={{
             padding: '10px',
           }}>
-            <input 
-              type="submit"  
-              value="Invite User"  
+            <input
+              type="submit"
+              value="Invite User"
               style={{
                 width: '150px',
             }} />

--- a/test-client/src/components/UserProfileForm.js
+++ b/test-client/src/components/UserProfileForm.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import localstorage from 'store2';
+import config from '../config';
 
 const fields = [
   { label: 'Name', id: 'name' },
@@ -55,7 +56,7 @@ class UserProfileForm extends Component {
     const headers = new Headers();
     headers.append('Authorization', `Bearer ${localstorage('accessToken')}`);
 
-    fetch('/api/user/profile', {
+    fetch(`${config.identityServer}api/user/profile`, {
       method: 'PUT',
       headers,
       body: data,

--- a/test-client/src/components/UserProfileForm.js
+++ b/test-client/src/components/UserProfileForm.js
@@ -1,0 +1,154 @@
+import React, { Component } from 'react';
+import localstorage from 'store2';
+
+const fields = [
+  { label: 'Name', id: 'name' },
+  { label: 'Given Name', id: 'given_name' },
+  { label: 'Family Name', id: 'family_name' },
+  { label: 'Middle Name', id: 'middle_name' },
+  { label: 'Nickname', id: 'nickname' },
+  { label: 'Preferred Username', id: 'preferred_username' },
+  { label: 'Profile', id: 'profile' },
+  { label: 'Website', id: 'website' },
+  { label: 'Email', id: 'email' },
+  { label: 'Gender', id: 'gender' },
+  { label: 'Birthdate', id: 'birthdate' },
+  { label: 'Phone Number', id: 'phone_number' },
+  { label: 'Street Address', id: 'address.street_address' },
+  { label: 'Locality', id: 'address.locality' },
+  { label: 'Region', id: 'address.region' },
+  { label: 'Postal Code', id: 'address.postal_code' },
+  { label: 'Country', id: 'address.country' },
+];
+
+const defaultFields = fields.reduce((acc, {id}) => ({ ...acc, [id]: ''}), {});
+
+class UserProfileForm extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showMessage: false,
+      message: '',
+      ...defaultFields,
+      picture: '',
+    };
+  }
+
+  updateForm(fieldName, e) {
+    const field = {};
+    field[fieldName] = (e.target.type === 'checkbox') 
+      ? e.target.checked : e.target.value;
+    this.setState(field);
+  }
+
+  submitForm(e) {
+    e.preventDefault();
+    const data = new FormData();
+
+    fields.forEach(({id}) => data.append(id, this.state[id]));
+    const file = this.pictureUpload.files[0];
+    if (file) {
+      data.append('picture', file, file.name);
+    }
+
+    const headers = new Headers();
+    headers.append('Authorization', `Bearer ${localstorage('accessToken')}`);
+
+    fetch('/api/user/profile', {
+      method: 'PUT',
+      headers,
+      body: data,
+    }).then((res) => res.json())
+      .then((data) => {
+        this.setState({ showMessage: true, message: 'Profile Updated' });
+        setTimeout(() => {
+          this.setState({ 
+            ...defaultFields,
+            showMessage: false,
+            message: '',
+            picture: '',
+          });
+        }, 1000);
+      });
+  }
+
+  renderField = ({ label, id }) => {
+    return (
+      <div style={{
+        padding: '10px',
+      }} key={id} >
+        <label htmlFor={id} style={{ width: '100px', textAlign: 'left' }}>{label}:</label>
+        <input 
+          type="text" 
+          name={id}
+          id={id} 
+          value={this.state[id]} 
+          placeholder={`Enter a ${label.toLowerCase()}`}
+          onChange={(e) => this.updateForm.call(this, id, e)}
+          style={{
+            width: '150px',
+          }} />
+      </div>
+    );
+  }
+
+  renderPictureUpload() {
+    return (
+      <div style={{
+        padding: '10px',
+      }}>
+        <label htmlFor="picture" style={{ width: '100px', textAlign: 'left' }}>Picture:</label>
+        <input 
+          type="file" 
+          name="picture"
+          id="picture"
+          accept="image/*"
+          value={this.state.picture.name} 
+          placeholder="Upload a picture"
+          onChange={(e) => {
+            const field = {picture: e.target.value};
+            this.setState(field);
+          }}
+          ref={ref => this.pictureUpload = ref}
+          style={{
+            width: '150px',
+          }} />
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <form
+          onSubmit={this.submitForm.bind(this)} 
+          style={{ 
+            border: 'thin solid black',
+            padding: '10px',
+            width: '400px',
+            marginLeft: 'auto',
+            marginRight: 'auto',
+          }}>
+          {fields.map(this.renderField)}
+          {this.renderPictureUpload()}
+          <div style={{
+            padding: '10px',
+          }}>
+            <input 
+              type="submit"  
+              value="Update User Profile"  
+              style={{
+                width: '150px',
+              }} />
+          </div>
+        </form>
+        {(this.state.showMessage) ? <div>
+          <h4>{this.state.message}</h4>
+        </div> : ''}
+      </div>
+    );
+  }
+}
+
+export default UserProfileForm;

--- a/test-client/src/components/UserProfileForm.js
+++ b/test-client/src/components/UserProfileForm.js
@@ -37,7 +37,7 @@ class UserProfileForm extends Component {
 
   updateForm(fieldName, e) {
     const field = {};
-    field[fieldName] = (e.target.type === 'checkbox') 
+    field[fieldName] = (e.target.type === 'checkbox')
       ? e.target.checked : e.target.value;
     this.setState(field);
   }
@@ -63,7 +63,7 @@ class UserProfileForm extends Component {
       .then((data) => {
         this.setState({ showMessage: true, message: 'Profile Updated' });
         setTimeout(() => {
-          this.setState({ 
+          this.setState({
             ...defaultFields,
             showMessage: false,
             message: '',
@@ -79,11 +79,11 @@ class UserProfileForm extends Component {
         padding: '10px',
       }} key={id} >
         <label htmlFor={id} style={{ width: '100px', textAlign: 'left' }}>{label}:</label>
-        <input 
-          type="text" 
+        <input
+          type="text"
           name={id}
-          id={id} 
-          value={this.state[id]} 
+          id={id}
+          value={this.state[id]}
           placeholder={`Enter a ${label.toLowerCase()}`}
           onChange={(e) => this.updateForm.call(this, id, e)}
           style={{
@@ -99,12 +99,12 @@ class UserProfileForm extends Component {
         padding: '10px',
       }}>
         <label htmlFor="picture" style={{ width: '100px', textAlign: 'left' }}>Picture:</label>
-        <input 
-          type="file" 
+        <input
+          type="file"
           name="picture"
           id="picture"
           accept="image/*"
-          value={this.state.picture.name} 
+          value={this.state.picture.name}
           placeholder="Upload a picture"
           onChange={(e) => {
             const field = {picture: e.target.value};
@@ -122,8 +122,8 @@ class UserProfileForm extends Component {
     return (
       <div>
         <form
-          onSubmit={this.submitForm.bind(this)} 
-          style={{ 
+          onSubmit={this.submitForm.bind(this)}
+          style={{
             border: 'thin solid black',
             padding: '10px',
             width: '400px',
@@ -135,9 +135,9 @@ class UserProfileForm extends Component {
           <div style={{
             padding: '10px',
           }}>
-            <input 
-              type="submit"  
-              value="Update User Profile"  
+            <input
+              type="submit"
+              value="Update User Profile"
               style={{
                 width: '150px',
               }} />

--- a/test-client/src/config.template.js
+++ b/test-client/src/config.template.js
@@ -4,4 +4,6 @@ module.exports = {
   postLogoutRedirectUri: 'https://sso-client.test:3000/logout',
   clientId: '',
   clientSecret: '',
+  identityServer: 'https://sso-client.test:9000/',
+  testServer: 'https://localhost:8080/',
 };

--- a/test-client/test-server/index.js
+++ b/test-client/test-server/index.js
@@ -14,7 +14,12 @@ const tokenHandler = require('./tokenHandler');
 const webhookHandler = require('./webhookHandler');
 
 const server = new Hapi.Server();
-server.connection({ port: 8080 });
+server.connection({
+  port: 8080,
+  routes: {
+    cors: { origin: ['*'] }
+  }
+});
 
 const validate = async (decoded, request, callback) => {
   try {


### PR DESCRIPTION
#376 

Only finished the route for authenticating via access_token

Couldn't figure out authenticating with client_credientials. Tried passing along in the body as FormData, and then tried with querystring, but the requirement of a redirect_uri when using the `clientValidator` became problematic because of 302 redirects.