### PR TITLE
allow `find()` to work when `dump` is undefined

### DIFF
--- a/api/src/lib/oidc-adapter/redis.js
+++ b/api/src/lib/oidc-adapter/redis.js
@@ -75,6 +75,9 @@ module.exports = (userService) => {
       }
       const { dump, ...rest } = data;
 
+      // ease the transition from 2.x to 3.0.0
+      if (!dump) return { ...rest };
+
       if (dump.accountId) {
         const user = await userService.findByIdForOidc(dump.accountId);
         if (!user) {


### PR DESCRIPTION
#297

Tokens from older versions might not have a `dump` key
so we want to support that until all tokens can be replaced