### PR TITLE
Enhancement/477

### DIFF
--- a/api/config.js
+++ b/api/config.js
@@ -17,7 +17,7 @@ var config = {
       port: process.env.REDIS_PORT || 6379,
       password: process.env.REDIS_PASSWORD,
       userSessionTrackingEnabled: process.env.ENABLE_USER_SESSION_TRACKING || false,
-      tls: process.env.REDIS_TLS ? { port: process.env.TLS_PORT || 6380 } : undefined,
+      tls: process.env.REDIS_TLS ? { port: process.env.REDIS_TLS_PORT || 6380 } : undefined,
     },
     email: process.env.OIDC_EMAIL_DRIVER,
     oidc: {

--- a/api/config.js
+++ b/api/config.js
@@ -15,6 +15,7 @@ var config = {
     redis: {
       host: process.env.REDIS_HOST || 'localhost',
       port: process.env.REDIS_PORT || 6379,
+      password: process.env.REDIS_PASSWORD,
       userSessionTrackingEnabled: process.env.ENABLE_USER_SESSION_TRACKING || false,
     },
     email: process.env.OIDC_EMAIL_DRIVER,

--- a/api/config.js
+++ b/api/config.js
@@ -17,6 +17,7 @@ var config = {
       port: process.env.REDIS_PORT || 6379,
       password: process.env.REDIS_PASSWORD,
       userSessionTrackingEnabled: process.env.ENABLE_USER_SESSION_TRACKING || false,
+      tls: process.env.REDIS_TLS ? { port: process.env.TLS_PORT || 6380 } : undefined,
     },
     email: process.env.OIDC_EMAIL_DRIVER,
     oidc: {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,8 @@ Each release of the Synapse OIDC Platform is built as a docker public docker ima
 | REDIS_HOST                | Set if different from default 'localhost' |
 | REDIS_PORT                | Set if different from default '6379' |
 | REDIS_PASSWORD            | Set if using password authentication for redis |
+| REDIS_TLS                 | Set to true if connecting to redis over SSL |
+| REDIS_TLS_PORT            | Set if different from default '6380' |
 | ENABLE_USER_SESSION_TRACKING | Set to true if you want to enable session tracking by user id in order to bulk delete sessions by user id at the `/user/invalidate-user-sessions` endpoint. |
 | KEEP_ALIVE_TIMEOUT | Duration for which OIDC will keep connections open with the client. This setting should be at least as long as the client's expecting connections to remain open e.g. ELB's `Idle timeout` setting. |
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,7 @@ Each release of the Synapse OIDC Platform is built as a docker public docker ima
 | ENABLE_USER_REGISTRATION  | Set to true if you want to enable user registration at the `/user/register` endpoint. If this is disabled client initiated invites is the only way to make new users |
 | REDIS_HOST                | Set if different from default 'localhost' |
 | REDIS_PORT                | Set if different from default '6379' |
+| REDIS_PASSWORD            | Set if using password authentication for redis |
 | ENABLE_USER_SESSION_TRACKING | Set to true if you want to enable session tracking by user id in order to bulk delete sessions by user id at the `/user/invalidate-user-sessions` endpoint. |
 | KEEP_ALIVE_TIMEOUT | Duration for which OIDC will keep connections open with the client. This setting should be at least as long as the client's expecting connections to remain open e.g. ELB's `Idle timeout` setting. |
 


### PR DESCRIPTION
#477 

Adding password auth and TLS support for redis connection. My intention with this change was to make password and tls optional and with `undefined` as the default, so that existing OIDC implementations would be completely unaffected.