### PR TITLE
Fix redis TLS configuration

### DIFF
--- a/api/config.js
+++ b/api/config.js
@@ -17,7 +17,7 @@ var config = {
       port: process.env.REDIS_PORT || 6379,
       password: process.env.REDIS_PASSWORD,
       userSessionTrackingEnabled: process.env.ENABLE_USER_SESSION_TRACKING || false,
-      tls: process.env.REDIS_TLS ? { port: process.env.REDIS_TLS_PORT || 6380 } : undefined,
+      ...(process.env.REDIS_TLS === 'true' ? true : false) ? {tls: { port: process.env.REDIS_TLS_PORT || 6380 }} : undefined,
     },
     email: process.env.OIDC_EMAIL_DRIVER,
     oidc: {


### PR DESCRIPTION
The ioredis configuration block appears to put precedence on the tls
block if it is defined. If REDIS_TLS is set to false, the ioredis
library will still try to use the tls block with default settings.
Conditionally defining the block resolves this issue.

This conditional could probably streamlined or written cleaner.