### PR TITLE
Fix redis TLS configuration

### DIFF
--- a/api/config.js
+++ b/api/config.js
@@ -17,7 +17,7 @@ var config = {
       port: process.env.REDIS_PORT || 6379,
       password: process.env.REDIS_PASSWORD,
       userSessionTrackingEnabled: process.env.ENABLE_USER_SESSION_TRACKING || false,
-      tls: process.env.REDIS_TLS ? { port: process.env.REDIS_TLS_PORT || 6380 } : undefined,
+      tls: process.env.REDIS_TLS === 'true' ? { port: process.env.REDIS_TLS_PORT || 6380 } : undefined,
     },
     email: process.env.OIDC_EMAIL_DRIVER,
     oidc: {


### PR DESCRIPTION
Update config.js to ensure REDIS_TLS works as expected when defined.

@spruce-bruce I was able to quickly verify this now works as expected.