### PR TITLE
Revert "Bugfix for redis connection hanging with AWS Elasticache Redis with TransmitEncryptionEnabled"

### DIFF
--- a/api/config.js
+++ b/api/config.js
@@ -17,7 +17,7 @@ var config = {
       port: process.env.REDIS_PORT || 6379,
       password: process.env.REDIS_PASSWORD,
       userSessionTrackingEnabled: process.env.ENABLE_USER_SESSION_TRACKING || false,
-      tls: process.env.REDIS_TLS === 'true' ? { port: process.env.REDIS_TLS_PORT || 6380 } : {},
+      tls: process.env.REDIS_TLS === 'true' ? { port: process.env.REDIS_TLS_PORT || 6380 } : undefined,
     },
     email: process.env.OIDC_EMAIL_DRIVER,
     oidc: {


### PR DESCRIPTION
Reverts synapsestudios/oidc-platform#496

This change was a mistake. Passing in any truthy value for the `tls` option means ioredis will use TLS, which makes the `REDIS_TLS` environment variable do nothing. This should remain as `undefined` and any projects that need to use AWS Elasticache Redis with TransmitEncryptionEnabled should set the `REDIS_TLS` environment variable on their oidc task definitions.

