### PR TITLE
Pass env cookie keys to the openid-connect provider configuration

### DIFF
--- a/api/src/plugins/openid-connect/getConfig.js
+++ b/api/src/plugins/openid-connect/getConfig.js
@@ -17,6 +17,7 @@ module.exports = options => {
     cookies: {
       long: { signed: true },
       short: { signed: true },
+      keys: options.keys
     },
     discovery: {
       service_documentation: '',

--- a/api/src/plugins/openid-connect/openid-connect.js
+++ b/api/src/plugins/openid-connect/openid-connect.js
@@ -19,6 +19,8 @@ exports.register = function (server, options, next) {
     RefreshToken: parseInt(process.env.REFRESH_TOKEN_EXP, 10),
   };
 
+  options.keys = [process.env.COOKIE_KEY, process.env.OLD_COOKIE_KEY];
+
   const prefix = options.prefix ? `/${options.prefix}` : '/op';
   const provider = new OidcProvider(issuer, getConfig(options));
 


### PR DESCRIPTION
Passes the env cookie keys to the OpenID Connect configuration and removes the console warning about cookies.keys being missing and its criticality to detecting tampered cookies.