### PR TITLE
Fix accept-invite webhooks

### DIFF
--- a/api/src/application/user/user-views.js
+++ b/api/src/application/user/user-views.js
@@ -335,7 +335,6 @@ module.exports = {
       client: client.serialize({strictOidc:true}),
       title: title,
       returnTo: (redirectSet) ? false : `${request.query.redirect_uri}`,
-      formAction: `/user/reset-password?${querystring.stringify(request.query)}`,
       error: !!error,
       validationErrorMessages: error && error.isBoom ? getValidationMessages(error) : error,
     };


### PR DESCRIPTION
#544

I wasn't super clear from the original PR that introduced this regression (#515) if it was trying to fix something else that I overlooked, but it causes the `set password` page to POST to the `reset password` page which bypasses the `accept-invite` webhook.